### PR TITLE
fix: Clean up all linting issues

### DIFF
--- a/lib/providers/verse_provider.dart
+++ b/lib/providers/verse_provider.dart
@@ -7,7 +7,7 @@ import '../utils/date_utils.dart';
 class VerseProvider with ChangeNotifier {
   bool _isLoading = false;
   String? _error;
-  Map<String, List<Verse>> _allVerses = {};
+  final Map<String, List<Verse>> _allVerses = {};
   List<Event> _allEvents = [];
   
   bool get isLoading => _isLoading;

--- a/lib/screens/age_group_screen.dart
+++ b/lib/screens/age_group_screen.dart
@@ -8,10 +8,10 @@ class AgeGroupScreen extends StatelessWidget {
   final String displayName;
   
   const AgeGroupScreen({
-    Key? key,
+    super.key,
     required this.sheetName,
     required this.displayName,
-  }) : super(key: key);
+  });
   
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/calendar_screen.dart
+++ b/lib/screens/calendar_screen.dart
@@ -6,7 +6,7 @@ import '../providers/verse_provider.dart';
 import '../models/event.dart';
 
 class CalendarScreen extends StatefulWidget {
-  const CalendarScreen({Key? key}) : super(key: key);
+  const CalendarScreen({super.key});
   
   @override
   State<CalendarScreen> createState() => _CalendarScreenState();

--- a/lib/services/excel_loader.dart
+++ b/lib/services/excel_loader.dart
@@ -1,4 +1,5 @@
 import 'package:excel/excel.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import '../models/verse.dart';
 import '../models/event.dart';
@@ -27,7 +28,7 @@ class ExcelLoader {
             final verseCell = sheet.cell(CellIndex.indexByColumnRow(columnIndex: 1, rowIndex: row));
             final dateCell = sheet.cell(CellIndex.indexByColumnRow(columnIndex: 2, rowIndex: row));
             
-            if (verseCell?.value != null && dateCell?.value != null) {
+            if (verseCell.value != null && dateCell.value != null) {
               final verseText = verseCell.value.toString();
               final dateValue = dateCell.value;
               
@@ -42,12 +43,12 @@ class ExcelLoader {
                 verses.add(Verse(
                   date: date,
                   text: verseText,
-                  extra: lessonCell?.value?.toString(),
+                  extra: lessonCell.value?.toString(),
                 ));
               }
             }
           } catch (e) {
-            print('Error parsing row $row in sheet $sheetName: $e');
+            debugPrint('Error parsing row $row in sheet $sheetName: $e');
           }
         }
         
@@ -56,7 +57,7 @@ class ExcelLoader {
       
       return result;
     } catch (e) {
-      print('Error loading Excel file: $e');
+      debugPrint('Error loading Excel file: $e');
       return {};
     }
   }
@@ -80,7 +81,7 @@ class ExcelLoader {
             final verseCell = sheet.cell(CellIndex.indexByColumnRow(columnIndex: 1, rowIndex: row));
             final dateCell = sheet.cell(CellIndex.indexByColumnRow(columnIndex: 2, rowIndex: row));
             
-            if (lessonCell?.value != null && dateCell?.value != null) {
+            if (lessonCell.value != null && dateCell.value != null) {
               final lessonName = lessonCell.value.toString();
               final dateValue = dateCell.value;
               
@@ -95,19 +96,19 @@ class ExcelLoader {
                 events.add(Event(
                   date: date,
                   title: '$sheetName - $lessonName',
-                  note: verseCell?.value?.toString(),
+                  note: verseCell.value?.toString(),
                 ));
               }
             }
           } catch (e) {
-            print('Error parsing event row $row in sheet $sheetName: $e');
+            debugPrint('Error parsing event row $row in sheet $sheetName: $e');
           }
         }
       }
       
       return events;
     } catch (e) {
-      print('Error loading events: $e');
+      debugPrint('Error loading events: $e');
       return [];
     }
   }

--- a/lib/services/verse_repository.dart
+++ b/lib/services/verse_repository.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models/verse.dart';
 import '../models/event.dart';
@@ -37,7 +38,7 @@ class VerseRepository {
       await eventsBox.put('all_events', {'events': eventsJson});
       
     } catch (e) {
-      print('Error loading and caching data: $e');
+      debugPrint('Error loading and caching data: $e');
       rethrow;
     }
   }
@@ -54,7 +55,7 @@ class VerseRepository {
       final List<dynamic> versesJson = data['verses'];
       return versesJson.map((json) => Verse.fromJson(Map<String, dynamic>.from(json))).toList();
     } catch (e) {
-      print('Error getting verses for sheet $sheetName: $e');
+      debugPrint('Error getting verses for sheet $sheetName: $e');
       return [];
     }
   }
@@ -71,7 +72,7 @@ class VerseRepository {
       final List<dynamic> eventsJson = data['events'];
       return eventsJson.map((json) => Event.fromJson(Map<String, dynamic>.from(json))).toList();
     } catch (e) {
-      print('Error getting events: $e');
+      debugPrint('Error getting events: $e');
       return [];
     }
   }

--- a/lib/widgets/verse_card.dart
+++ b/lib/widgets/verse_card.dart
@@ -9,12 +9,12 @@ class VerseCard extends StatelessWidget {
   final VerseProvider provider;
   
   const VerseCard({
-    Key? key,
+    super.key,
     required this.title,
     required this.weekType,
     required this.sheetName,
     required this.provider,
-  }) : super(key: key);
+  });
   
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
# fix: Clean up all linting issues

## Summary
This PR resolves all 15 info-level linting issues that were causing CI failures. The changes focus on code quality improvements and adherence to Flutter/Dart best practices:

- **Replaced `print()` with `debugPrint()`**: All production print statements in `excel_loader.dart` and `verse_repository.dart` have been updated to use `debugPrint()` for proper debug-only logging
- **Modernized constructor parameters**: Updated widget constructors to use `super.key` instead of the deprecated `Key? key` pattern
- **Improved immutability**: Made `_allVerses` field final in `VerseProvider` for better state management
- **Removed unnecessary null-aware operators**: Cleaned up redundant `?.` operators where static analysis confirmed they weren't needed
- **Added proper imports**: Included `flutter/foundation.dart` for `debugPrint` usage

## Review & Testing Checklist for Human
- [ ] **Test Excel data loading**: Verify that verse and event data still loads correctly from the Excel file (most critical since this is where print statements were changed)
- [ ] **Test all app screens**: Navigate through all tabs (Calendar, 유치부, 초등부, 중고등부) to ensure UI still renders properly with updated constructors
- [ ] **Verify error handling**: Check that error messages still appear correctly if Excel loading fails (debugPrint changes could affect debugging)
- [ ] **Run full app locally**: Execute `flutter run` and perform basic user flows to confirm no runtime regressions

**Recommended test plan**: Open the app, navigate to each age group tab, verify verses display correctly, check calendar functionality, and intentionally cause an error (e.g., remove Excel file temporarily) to verify error handling still works.

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    App["lib/main.dart"]:::context
    Provider["lib/providers/<br/>verse_provider.dart"]:::minor-edit
    Screens["lib/screens/<br/>age_group_screen.dart<br/>calendar_screen.dart"]:::minor-edit
    Widgets["lib/widgets/<br/>verse_card.dart"]:::minor-edit
    Services["lib/services/<br/>excel_loader.dart<br/>verse_repository.dart"]:::major-edit
    Models["lib/models/<br/>verse.dart<br/>event.dart"]:::context
    
    App --> Provider
    Provider --> Services
    Services --> Models
    Screens --> Provider
    Screens --> Widgets
    Widgets --> Provider
    
    subgraph Legend
        L1["Major Edit<br/>(print → debugPrint)"]:::major-edit
        L2["Minor Edit<br/>(super.key, final)"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6
    classDef context fill:#FFFFFF
```

### Notes
- All changes are backward-compatible and should not affect app functionality
- The `debugPrint` changes mean error logs will only appear in debug builds, not production (which is the intended behavior)
- CI should now pass cleanly with 0 linting issues
- These changes prepare the codebase for future development with cleaner, more maintainable code

---
**Link to Devin run**: https://app.devin.ai/sessions/80469388d0394fb99b919b1bef2e8f85    
**Requested by**: @Kim-Hakseong